### PR TITLE
Backwards compatibility for profile scores

### DIFF
--- a/model-services/PrismaScoreService.ts
+++ b/model-services/PrismaScoreService.ts
@@ -1,5 +1,9 @@
 import Logger from "../lib/Logger";
-import { medalToNormalStar, scoreToMedal } from "../utilities/scoreToMedal";
+import {
+  isNewMedalBetter,
+  medalToNormalStar,
+  scoreToMedal,
+} from "../utilities/scoreToMedal";
 import { PrismaInstance } from "../website/beatstar/src/lib/prisma";
 import { getBeatmap } from "./PrismaBeatmapService";
 
@@ -102,7 +106,7 @@ export const tryToUpdateScore = async (
 
   // do we need to update the starCount?
   if (!isCustom) {
-    if (oldMedal !== newMedal) {
+    if (isNewMedalBetter(oldMedal, newMedal, beatmap.deluxe)) {
       const oldStarCount = medalToNormalStar(oldMedal);
       const newStarCount = medalToNormalStar(newMedal);
 

--- a/utilities/scoreToMedal.ts
+++ b/utilities/scoreToMedal.ts
@@ -10,6 +10,24 @@ DELUXE_GOLD = 9
 DELUXE_PLATINUM = 10
 DELUXE_DIAMOND = 11*/
 
+export const isNewMedalBetter = (
+  oldMedal: number,
+  newMedal: number,
+  isDeluxe?: boolean
+) => {
+  if (!oldMedal) {
+    return true;
+  }
+  const normalMedals = [1, 2, 5, 3, 4, 6, 7, 8];
+  const deluxeMedals = [1, 2, 5, 3, 4, 9, 10, 11];
+
+  const table = isDeluxe ? deluxeMedals : normalMedals;
+
+  const oldIndex = table.indexOf(oldMedal);
+  const newIndex = table.indexOf(newMedal);
+  return newIndex > oldIndex;
+};
+
 /**
  * Given a goofy Beatstar medal index convert it to normal
  * @param medal Goofy Beatstar medal index from the above table

--- a/website/beatstar/src/routes/(profile)/profile/+page.server.ts
+++ b/website/beatstar/src/routes/(profile)/profile/+page.server.ts
@@ -72,7 +72,7 @@ export const actions = {
 		const currentScores = await prisma.score.findMany({
 			where: {
 				beatmapId: {
-					in: uploadedBeatmapScores.map((beatmap) => beatmap.template_id)
+					in: uploadedBeatmapScores.map((beatmap) => beatmap.template_id ? beatmap.template_id : beatmap.templateId)
 				},
 				userId: user.id
 			}
@@ -83,7 +83,7 @@ export const actions = {
 
 		for (const uploadedScore of uploadedBeatmapScores) {
 			const currentScore = currentScores.find(
-				(score) => score.beatmapId === uploadedScore.template_id
+				(score) => score.beatmapId === uploadedScore.template_id ? uploadedScore.template_id : uploadedScore.templateId
 			);
 			if (currentScore === undefined) {
 				scoresToAdd.push(uploadedScore);
@@ -94,10 +94,10 @@ export const actions = {
 
 		await prisma.score.createMany({
 			data: scoresToAdd.map((score) => ({
-				beatmapId: score.template_id,
+				beatmapId: score.template_id ? score.template_id : score.templateId,
 				normalizedScore: score.HighestScore.normalizedScore,
 				absoluteScore: score.HighestScore.absoluteScore,
-				highestGrade: score.HighestGrade_id,
+				highestGrade: score.HighestGrade_id ? score.HighestGrade_id : score.HighestGradeId,
 				highestCheckpoint: score.HighestCheckpoint,
 				highestStreak: score.HighestStreak,
 				playedCount: score.PlayedCount,
@@ -110,7 +110,7 @@ export const actions = {
 				data: {
 					normalizedScore: score.HighestScore.normalizedScore,
 					absoluteScore: score.HighestScore.absoluteScore,
-					highestGrade: score.HighestGrade_id,
+					highestGrade: score.HighestGrade_id ? score.HighestGrade_id : score.HighestGradeId,
 					highestCheckpoint: score.HighestCheckpoint,
 					highestStreak: score.HighestStreak,
 					playedCount: score.PlayedCount
@@ -118,7 +118,7 @@ export const actions = {
 				where: {
 					userId_beatmapId: {
 						userId: user.id,
-						beatmapId: score.template_id
+						beatmapId: score.template_id ? score.template_id : score.templateId
 					}
 				}
 			});

--- a/website/beatstar/src/routes/(profile)/profile/+page.server.ts
+++ b/website/beatstar/src/routes/(profile)/profile/+page.server.ts
@@ -59,7 +59,7 @@ export const actions = {
 			});
 		}
 
-		const uploadedScores = json.profile.beatmaps.beatmaps;
+		const uploadedScores = (json.profile === undefined && json.beatmaps !== undefined) ? json.beatmaps.beatmaps : json.profile.beatmaps.beatmaps;
 
 		if (!user) {
 			return fail(500);


### PR DESCRIPTION
Older profile.json exports start from the .profile object (they don't contain liveops configs, etc., essentially the profile.json is "config = config.profile"). 

This adds a check if .profile doesn't exist and .beatmaps do to load the scores respective to the json format.