### PR TITLE
Update all scores from profile.json, not just higher ones

### DIFF
--- a/website/beatstar/src/routes/(profile)/profile/+page.server.ts
+++ b/website/beatstar/src/routes/(profile)/profile/+page.server.ts
@@ -87,16 +87,7 @@ export const actions = {
 		const scoresToUpdate = [];
 
 		for (const uploadedScore of uploadedBeatmapScores) {
-			const currentScore = currentScores.find((score) =>
-				score.beatmapId === uploadedScore.template_id
-					? uploadedScore.template_id
-					: uploadedScore.templateId
-			);
-			if (currentScore === undefined) {
-				scoresToAdd.push(uploadedScore);
-			} else if (currentScore.absoluteScore < uploadedScore.HighestScore.absoluteScore) {
-				scoresToUpdate.push(uploadedScore);
-			}
+			scoresToAdd.push(uploadedScore);
 		}
 
 		await prisma.score.createMany({


### PR DESCRIPTION
As talked about on Discord, this change would update all scores from the uploaded profile.json, not just the ones that are higher than the current score. This would allow for overwriting scores that were accidentally saved as too high and in general reset scores (which I desperately need in my case).

The "restore" button could still become a separate feature, but I don't see why these two things would conflict with each other.

It also wouldn't cause any issues for other people as profile.json files normally should not contain songs with scores of zero.